### PR TITLE
Don't delete version. Fixes #3.

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,6 @@ function sync(config, patterns, options) {
     config.authors = authors;
   }
 
-  delete config.version;
   return keys(config, patterns, opts);
 }
 


### PR DESCRIPTION
By not deleting `version`, yet not including in default filter keys, it becomes opt-in to sync.